### PR TITLE
Handle trailing comments on a hosts file line.

### DIFF
--- a/txeh.go
+++ b/txeh.go
@@ -45,6 +45,7 @@ type HostFileLine struct {
 	Hostnames       []string
 	Raw             string
 	Trimed          string
+	Comment         string
 }
 
 // NewHostsDefault returns a hosts object with
@@ -322,6 +323,12 @@ func ParseHosts(path string) ([]HostFileLine, error) {
 			continue
 		}
 
+		curLineSplit := strings.SplitN(curLine.Trimed, "#", 2)
+		if len(curLineSplit) > 1 {
+			curLine.Comment = curLineSplit[1]
+		}
+		curLine.Trimed = curLineSplit[0]
+
 		curLine.Parts = strings.Fields(curLine.Trimed)
 
 		if len(curLine.Parts) > 1 {
@@ -361,5 +368,8 @@ func lineFormatter(hfl HostFileLine) string {
 		return hfl.Raw
 	}
 
+	if len(hfl.Comment) > 0 {
+		return fmt.Sprintf("%-16s %s #%s", hfl.Address, strings.Join(hfl.Hostnames, " "), hfl.Comment)
+	}
 	return fmt.Sprintf("%-16s %s", hfl.Address, strings.Join(hfl.Hostnames, " "))
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

The current `ParseHosts` implementation does not take into consideration trailing comments in an /etc/hosts entry. For such an entry, the `AddHosts` API fails, as it adds an entry as a comment. For ex.
For the following /etc/hosts file
```
# comment 1
# comment 2

127.0.0.1 localhost # some comment
```
AddHosts("127.0.0.1", "localhost-1") will update the /etc/hosts file incorrectly like this
```
# comment 1
# comment 2

127.0.0.1 localhost # some comment localhost-1
```

This PR addresses the above problem. 