### PR TITLE
Add 'show' argument to print the /etc/hosts file

### DIFF
--- a/util/cmd/root.go
+++ b/util/cmd/root.go
@@ -143,5 +143,4 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	return
 }

--- a/util/cmd/show.go
+++ b/util/cmd/show.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(showCmd)
+}
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show hostnames in /etc/hosts",
+	Long:  `Show the content of the /etc/hosts file `,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ShowHosts()
+	},
+}
+
+func ShowHosts() {
+	fmt.Print(etcHosts.RenderHostsFile())
+}


### PR DESCRIPTION
Fixes #4 

Adds the `show` argument that simply prints the `/etc/hosts` file