### PR TITLE
use %SystemRoot% environment variable for hosts file location on Windows

### DIFF
--- a/txeh.go
+++ b/txeh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -72,7 +73,7 @@ func NewHosts(hc *HostsConfig) (*Hosts, error) {
 	defaultHostsFile := "/etc/hosts"
 
 	if runtime.GOOS == "windows" {
-		defaultHostsFile = `C:\Windows\System32\Drivers\etc\hosts`
+		defaultHostsFile = winDefaultHostsFile()
 	}
 
 	if h.ReadFilePath == "" && h.RawText == nil {
@@ -518,4 +519,16 @@ var localhostIPRegexp = regexp.MustCompile(ipLocalhost)
 
 func isLocalhost(address string) bool {
 	return localhostIPRegexp.MatchString(address)
+}
+
+// winDefaultHostsFile returns the default hosts file path for Windows
+// it tries to use the SystemRoot environment variable, if that is not set
+// it falls back to C:\Windows\System32\Drivers\etc\hosts
+func winDefaultHostsFile() string {
+	if r := os.Getenv("SystemRoot"); r != "" {
+		return filepath.Join(r, "System32", "drivers", "etc", "hosts")
+	}
+
+	// fallback to C:\
+	return `C:\Windows\System32\drivers\etc\hosts`
 }

--- a/txeh_test.go
+++ b/txeh_test.go
@@ -1,6 +1,8 @@
 package txeh
 
 import (
+	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -302,4 +304,44 @@ func TestMethods(t *testing.T) {
 		t.Fatalf("Expeced \"%s\" on line %d. Got \"%s\"", expectString, line, hfl[line])
 	}
 
+}
+
+func TestWinDefaultHostsFile(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Skipping windows test")
+	}
+
+	tc := []struct {
+		Name     string
+		EnvVaule string
+		Expect   string
+	}{
+		{
+			Name:     "Correct SystemRoot environment variable",
+			EnvVaule: "E:\\Windows",
+			Expect:   "E:\\Windows\\System32\\drivers\\etc\\hosts",
+		},
+		{
+			Name:     "SystemRoot with trailing slash",
+			EnvVaule: "E:\\Windows\\",
+			Expect:   "E:\\Windows\\System32\\drivers\\etc\\hosts",
+		},
+		{
+			Name:     "No systemRoot environment variable",
+			EnvVaule: "",
+			Expect:   "C:\\Windows\\System32\\drivers\\etc\\hosts",
+		},
+	}
+	for _, tt := range tc {
+		t.Run(tt.Name, func(t *testing.T) {
+			if err := os.Setenv("SystemRoot", tt.EnvVaule); err != nil {
+				panic(err)
+			}
+			hostFile := winDefaultHostsFile()
+			if hostFile != tt.Expect {
+				t.Fatalf("TestWinDefaultHostsFile failed to get expected path: "+
+					"expect: %v, got: %v", tt.Expect, hostFile)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This Pull Request aims to enhance the method for locating the hosts file on Windows systems by utilizing the SystemRoot environment variable, ensuring a more reliable approach.

it first try to get `$SystemRoot` environment variable, if the environment variable is not set, fallback to `C:\Windows\System32\Drivers\etc\hosts`

[document about SystemRoot](https://learn.microsoft.com/en-us/windows/deployment/usmt/usmt-recognized-environment-variables#variables-that-are-processed-for-the-operating-system-and-in-the-context-of-each-user)