### PR TITLE
fix: update cosign signing to use --bundle flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,17 +57,14 @@ checksum:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    certificate: '${artifact}.pem'
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      - '--bundle=${signature}'
       - '${artifact}'
       - '--yes'
     artifacts: checksum
     output: true
+    signature: '${artifact}.bundle'
 
 sboms:
   - artifacts: archive


### PR DESCRIPTION
## Summary

- Update `.goreleaser.yml` cosign signing config for cosign v2.4+
- Replace deprecated `--output-certificate` and `--output-signature` with `--bundle`
- Remove deprecated `COSIGN_EXPERIMENTAL=1` env var (keyless signing is now default)

## Context

Release v1.7.1 failed at the signing step with:
```
must provide --bundle with --signing-config or --use-signing-config
```

## Validated locally

- `goreleaser check` passes
- `goreleaser release --snapshot --clean` builds all platforms successfully
- `cosign sign-blob --bundle` flag confirmed in local cosign