### PR TITLE
fix: use HOMEBREW_TAP_TOKEN for homebrew formula push

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,6 +116,7 @@ brews:
     repository:
       owner: txn2
       name: homebrew-tap
+      token: '{{ .Env.HOMEBREW_TAP_TOKEN }}'
     commit_author:
       name: Craig Johnston
       email: cj@imti.co


### PR DESCRIPTION
## Summary

- Add explicit `token` field to goreleaser `brews.repository` config so it uses `HOMEBREW_TAP_TOKEN` instead of the default `GITHUB_TOKEN`

## Context

Release v1.7.1 signing succeeded (#40) but the homebrew formula push to `txn2/homebrew-tap` failed with:
```
403 Resource not accessible by integration []
```

The default `GITHUB_TOKEN` only has access to the current repo, not `txn2/homebrew-tap`.

## Validated locally

- `goreleaser check` passes