### PR TITLE
housekeeping: fix OpenSSF Scorecard token permissions and pin docs deps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,10 +9,13 @@ on:
     - cron: '0 0 * * 0'  # Weekly
 
 permissions:
-  security-events: write
+  contents: read
 
 jobs:
   analyze:
+    permissions:
+      contents: read
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -19,6 +17,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -39,6 +39,9 @@ jobs:
           path: site/
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,14 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write  # For Cosign keyless signing
+  contents: read
 
 jobs:
   release:
+    permissions:
+      contents: write
+      packages: write
+      id-token: write  # For Cosign keyless signing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,11 +7,14 @@ on:
     - cron: '0 0 * * 0'  # Weekly
 
 permissions:
-  security-events: write
-  id-token: write
+  contents: read
 
 jobs:
   analysis:
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
-mkdocs>=1.6.0
-mkdocs-material>=9.6.0
+mkdocs==1.6.1
+mkdocs-material==9.7.1


### PR DESCRIPTION
## Summary

- Move write permissions from workflow top-level to individual job level in `codeql.yml`, `scorecard.yml`, `release.yml`, and `docs.yml` — all workflows now declare `contents: read` at top level, satisfying the OpenSSF Scorecard Token-Permissions check
- Pin `mkdocs` and `mkdocs-material` to exact versions in `requirements-docs.txt` to satisfy the Pinned-Dependencies check

## Expected Scorecard Impact

| Check | Before | After |
|-------|--------|-------|
| Token-Permissions | 0/10 | 10/10 |
| Pinned-Dependencies | 9/10 | 10/10 |

## Note

Branch-Protection (8/10) requires manual changes in the GitHub UI (enforce admins, increase required reviewers to 2) — not addressable via code.

## Test plan

- [x] Verify `actionlint` passes on all modified workflows (confirmed locally)
- [x] CI passes on this PR
- [ ] Scorecard re-runs after merge and reflects improved scores