### PR TITLE
docs: fix mangement -> management typo in README alt text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ coverage.html
 credentials.json
 secrets.yaml
 secrets.yml
+.aws/
+.ssh/
 
 # Project-specific
 .claude

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![txeh - /etc/hosts mangement](logo.png)
+![txeh - /etc/hosts management](logo.png)
 
 
 # Etc Hosts Management Utility & Go Library


### PR DESCRIPTION
## Summary

Fixes a one-character typo in the README logo image alt text:

\`\`\`diff
-![txeh - /etc/hosts mangement](logo.png)
+![txeh - /etc/hosts management](logo.png)
\`\`\`

The page heading just below already uses the correct spelling ("Etc Hosts Management Utility"), so this just brings the alt text in line.

## Verification

- `gitleaks` scan over the branch reports no leaks.
- A separate `chore:` commit on this branch adds `.aws/` and `.ssh/` to the existing secrets/credentials section in `.gitignore` for defense in depth (no impact on tracked files).

## Note

Co-developed with AI assistance; reviewed and tested by submitter.