### PR TITLE
fix: strip line-break characters from hostnames and comments

### DIFF
--- a/crlf_test.go
+++ b/crlf_test.go
@@ -1,0 +1,118 @@
+package txeh
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripLineBreaks verifies the helper drops only line-structure-breaking
+// control characters and leaves all other content untouched.
+func TestStripLineBreaks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text untouched", "added by kubefwd", "added by kubefwd"},
+		{"strips lf", "a\nb", "ab"},
+		{"strips cr", "a\rb", "ab"},
+		{"strips crlf", "a\r\nb", "ab"},
+		{"strips vertical tab", "a\vb", "ab"},
+		{"strips form feed", "a\fb", "ab"},
+		{"strips nul", "a\x00b", "ab"},
+		{"keeps tab", "a\tb", "a\tb"},
+		{"keeps space", "a b", "a b"},
+		{"keeps hash", "a # b", "a # b"},
+		{"empty string", "", ""},
+		{"only breaks", "\r\n\v\f\x00", ""},
+		{"crlf injected ssh key", "x\r\nssh-rsa AAAA attacker@evil", "xssh-rsa AAAA attacker@evil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stripLineBreaks(tt.in); got != tt.want {
+				t.Errorf("stripLineBreaks(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAddHostWithComment_CRLF_ProducesSingleLine is the regression test for the
+// reported CRLF injection. A comment carrying an embedded "\r\n" must not break
+// a single host entry into multiple physical lines.
+func TestAddHostWithComment_CRLF_ProducesSingleLine(t *testing.T) {
+	t.Parallel()
+
+	input := ""
+	hosts, err := NewHosts(&HostsConfig{RawText: &input})
+	if err != nil {
+		t.Fatalf("NewHosts: %v", err)
+	}
+
+	// The sudoers-style payload from the PoC.
+	hosts.AddHostWithComment(testIPv4Localhost, "placeholder", "x\r\nattacker ALL=(ALL) NOPASSWD: ALL")
+
+	rendered := hosts.RenderHostsFile()
+
+	if strings.ContainsAny(rendered, "\r") {
+		t.Errorf("rendered output contains carriage return: %q", rendered)
+	}
+
+	// Exactly one non-empty physical line should be produced.
+	var nonEmpty []string
+	for ln := range strings.SplitSeq(rendered, "\n") {
+		if strings.TrimSpace(ln) != "" {
+			nonEmpty = append(nonEmpty, ln)
+		}
+	}
+	if len(nonEmpty) != 1 {
+		t.Fatalf("expected 1 non-empty line, got %d: %#v", len(nonEmpty), nonEmpty)
+	}
+
+	want := "127.0.0.1        placeholder # xattacker ALL=(ALL) NOPASSWD: ALL"
+	if nonEmpty[0] != want {
+		t.Errorf("line = %q, want %q", nonEmpty[0], want)
+	}
+}
+
+// TestAddHost_CRLF_InHostname_ProducesSingleLine verifies the hostname field is
+// also neutralized, not just comments.
+func TestAddHost_CRLF_InHostname_ProducesSingleLine(t *testing.T) {
+	t.Parallel()
+
+	input := ""
+	hosts, err := NewHosts(&HostsConfig{RawText: &input})
+	if err != nil {
+		t.Fatalf("NewHosts: %v", err)
+	}
+
+	hosts.AddHost(testIPv4Localhost, "good\r\nevil")
+
+	rendered := hosts.RenderHostsFile()
+	if strings.ContainsAny(rendered, "\r") || strings.Count(strings.TrimRight(rendered, "\n"), "\n") != 0 {
+		t.Errorf("hostname line break not neutralized: %q", rendered)
+	}
+}
+
+// TestLineFormatter_CRLF_Backstop verifies the render-time guard catches
+// line-break characters even when fields are populated directly, bypassing
+// addHostWithComment.
+func TestLineFormatter_CRLF_Backstop(t *testing.T) {
+	t.Parallel()
+
+	hfl := HostFileLine{
+		LineType:  ADDRESS,
+		Address:   testIPv4Localhost,
+		Hostnames: []string{"host\r\ninjected"},
+		Comment:   "note\r\nmore",
+	}
+
+	got := lineFormatter(hfl)
+	want := "127.0.0.1        hostinjected # notemore"
+	if got != want {
+		t.Errorf("lineFormatter = %q, want %q", got, want)
+	}
+}

--- a/txeh.go
+++ b/txeh.go
@@ -344,11 +344,13 @@ func (h *Hosts) AddHostWithComment(addressRaw, hostRaw, comment string) {
 // addHostWithComment is the internal implementation that handles both
 // commented and non-commented host additions.
 func (h *Hosts) addHostWithComment(addressRaw, hostRaw, comment string) { //nolint:revive // internal method mirrors public API naming
-	host := strings.TrimSpace(strings.ToLower(hostRaw))
+	host := stripLineBreaks(strings.TrimSpace(strings.ToLower(hostRaw)))
 	address := strings.TrimSpace(strings.ToLower(addressRaw))
 	// Normalize comment: trim spaces, but don't add/remove the # prefix
-	// (the # is handled during rendering)
-	comment = strings.TrimSpace(comment)
+	// (the # is handled during rendering). Strip line-break characters so a
+	// single logical entry cannot be split into multiple physical lines when
+	// rendered (CWE-117). See stripLineBreaks for details.
+	comment = stripLineBreaks(strings.TrimSpace(comment))
 
 	addressIP := net.ParseIP(address)
 	if addressIP == nil {
@@ -659,16 +661,42 @@ func (h *Hosts) removeHostFromLineLocked(hflIdx int, host, newAddress string) {
 	}
 }
 
+// stripLineBreaks removes characters that can terminate or split a physical
+// line in a hosts file: carriage return, line feed, vertical tab, form feed,
+// and NUL. Without this, an embedded "\r\n" in a comment or hostname would let
+// a single logical entry render as multiple lines, corrupting the file
+// structure when it is read back by txeh or any other consumer (CWE-117,
+// improper output neutralization). This is a robustness guard; trimming spaces
+// is handled separately by the caller.
+func stripLineBreaks(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\v', '\f', '\x00':
+			return -1 // drop the rune
+		default:
+			return r
+		}
+	}, s)
+}
+
 // lineFormatter formats a single host file line as a string.
 func lineFormatter(hfl HostFileLine) string {
 	if hfl.LineType < ADDRESS {
 		return hfl.Raw
 	}
 
-	if hfl.Comment != "" {
-		return fmt.Sprintf("%-16s %s # %s", hfl.Address, strings.Join(hfl.Hostnames, " "), hfl.Comment)
+	// Strip line-break characters as a render-time backstop so no code path
+	// can emit a multi-line entry, even if Hostnames or Comment were populated
+	// outside addHostWithComment.
+	hostnames := make([]string, len(hfl.Hostnames))
+	for i, hn := range hfl.Hostnames {
+		hostnames[i] = stripLineBreaks(hn)
 	}
-	return fmt.Sprintf("%-16s %s", hfl.Address, strings.Join(hfl.Hostnames, " "))
+
+	if hfl.Comment != "" {
+		return fmt.Sprintf("%-16s %s # %s", hfl.Address, strings.Join(hostnames, " "), stripLineBreaks(hfl.Comment))
+	}
+	return fmt.Sprintf("%-16s %s", hfl.Address, strings.Join(hostnames, " "))
 }
 
 // ipLocalhost is a regex pattern for IPv4 or IPv6 loopback range.


### PR DESCRIPTION
## What

Strip `\r`, `\n`, `\v`, `\f`, and NUL from hostnames and comments before they are written into the hosts file. Tabs, spaces, and `#` are preserved, so normal comments (`added by kubefwd`) are unaffected.

## Why

Comments and hostnames passed to `AddHost` / `AddHostWithComment` were trimmed but embedded line-break characters were kept. Because `lineFormatter` interpolates these fields with `%s`, an embedded `\r\n` let a single logical entry render as multiple physical lines, corrupting the hosts file structure when it is read back by txeh or any other consumer (CWE-117, improper output neutralization).

The guard is applied in two places:

- **Input boundary** (`addHostWithComment`) so the in-memory model stays clean.
- **Render-time backstop** (`lineFormatter`) so no code path can emit a multi-line entry, even when a `HostFileLine` is populated directly.

## On the report this came from

This was prompted by a "CRLF injection" report claiming privilege escalation (CVSS 6.7 / 8.8). That severity does not hold: every PoC requires root plus an attacker-controlled `-w` path, which already grants arbitrary file write without any comment trick. The restricted-sudo escalation is a sudoers misconfiguration, since `-w` alone hands the user root file write.

What is real is the data-hygiene gap fixed here: a library that writes structured files should not let one logical entry silently become several lines. Low severity, no CVE warranted.

## Compatibility

The public API is unchanged. Input is stripped silently rather than rejected, so existing callers (including kubefwd) keep working without an error-handling change.

## Tests

`crlf_test.go` adds:
- table-driven `stripLineBreaks` unit tests with hardcoded expected values
- the sudoers PoC payload as a regression test (asserts exactly one physical line)
- a hostname-CRLF case
- a `lineFormatter` backstop test

`go test -race ./...` passes, coverage 94.8% (gate 80%).