### PR TITLE
docs: publish Sourcey-generated Go reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'sourcey.config.ts'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.go'
   workflow_dispatch:
 
 permissions:
@@ -27,11 +31,21 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: '24'
+
       - name: Install dependencies
         run: pip install -r requirements-docs.txt
 
       - name: Build docs
         run: mkdocs build --strict
+
+      - name: Build Sourcey reference
+        run: |
+          npx --yes sourcey@3.6.5 build --output site/reference
+          mkdir -p site/reference/api
+          cp site/reference/api.html site/reference/api/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - CLI Reference: cli.md
   - Go Library: library.md
   - API Reference: api.md
+  - Sourcey Reference: https://txeh.txn2.com/reference/
   - Troubleshooting: troubleshooting.md
 
 extra:

--- a/sourcey.config.ts
+++ b/sourcey.config.ts
@@ -1,0 +1,25 @@
+export default {
+  name: "txeh Reference",
+  siteUrl: "https://txeh.txn2.com",
+  baseUrl: "/reference",
+  repo: "https://github.com/txn2/txeh",
+  editBranch: "master",
+  navigation: {
+    tabs: [
+      {
+        tab: "Guides",
+        slug: "",
+        mkdocs: "./mkdocs.yml",
+      },
+      {
+        tab: "Go API",
+        slug: "api",
+        godoc: {
+          module: ".",
+          packages: ["./..."],
+          mode: "live",
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

- keep the existing MkDocs site and theme unchanged
- publish a Sourcey-generated Go reference under `/reference/`
- generate package documentation from the checked-out Go source during the existing Pages workflow
- link the generated reference from the MkDocs navigation

## Rationale

The current guides remain the best entry point for users, while the generated reference gives maintainers and consumers a searchable view of exported packages and symbols that stays synchronized with the source. No generated HTML is committed.

Sourcey is pinned to `3.6.5`, and the build runs from the same checkout that Pages deploys. The small compatibility copy keeps Sourcey's Go API tab route working with its default flat HTML output.

## Validation

- `npx --yes sourcey@3.6.5 build --output site/reference`
- 9 Sourcey-rendered pages generated from the existing MkDocs content and live godoc adapter
- browser-checked the reference home, Getting Started, CLI Reference, Go Library, Go API overview, and package pages under `/reference/`
- `git diff --check`

`go test ./...` still has the repository's existing Windows-only failures where DNS-flush tests stub the Unix `true` command; this change does not modify Go code.
