### PR TITLE
docs: graphite re-skin (type, color, chrome)

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -23,8 +23,6 @@
   <div class="rail__meta">
     <span class="rail__rel">v1.8.0</span>
     <span class="rail__dot" aria-hidden="true">●</span>
-    <span data-clock>·· UTC</span>
-    <span class="rail__dot" aria-hidden="true">●</span>
     <a href="https://txn2.com" class="rail__org">part of <em class="serif">txn2</em>&nbsp;↗</a>
   </div>
   <nav class="rail__nav" aria-label="primary">
@@ -70,7 +68,6 @@
     <h1 class="hero__display">
       <span class="hero__row hero__row--1">
         <em class="serif">txeh</em>
-        <span class="hero__chip">v1.8.0 · go</span>
       </span>
       <span class="hero__row hero__row--2">
         <span class="outline">/etc/hosts</span>
@@ -82,7 +79,7 @@
 
     <div class="hero__intro">
       <p class="hero__lede">
-        <span class="dropcap">t</span>xeh manages the <code>/etc/hosts</code> file from Go and from the shell. Add, remove, list, and query hostname-to-IP mappings without hand-editing. Mutex-protected for safe concurrent use, comment-aware so entries from different sources stay separable, and cross-platform across Linux, macOS, and Windows. The library powers <a href="https://kubefwd.com">kubefwd</a>'s per-service hostname resolution and ships as a standalone CLI.
+        txeh manages the <code>/etc/hosts</code> file from Go and from the shell. Add, remove, list, and query hostname-to-IP mappings without hand-editing. Mutex-protected for safe concurrent use, comment-aware so entries from different sources stay separable, and cross-platform across Linux, macOS, and Windows. The library powers <a href="https://kubefwd.com">kubefwd</a>'s per-service hostname resolution and ships as a standalone CLI.
       </p>
       <p class="hero__lede hero__lede--muted">
         IPv4 and IPv6, CIDR-based bulk add and remove, dry-run preview, optional DNS cache flush after writes, and an in-memory mode that operates on raw text instead of a file. Apache 2.0, originally built to support <a href="https://github.com/txn2/kubefwd">kubefwd</a> for Kubernetes service forwarding.
@@ -214,71 +211,57 @@ _ = hosts.Save()</pre>
       </p>
     </header>
 
-    <ol class="stack">
+    <ul class="stack">
       <li class="stack__row">
-        <span class="stack__num">001</span>
         <div class="stack__main">
           <a class="stack__name" href="library/#adding-hosts">add and remove by host, ip, or cidr</a>
           <p class="stack__desc">Single-host or bulk operations. <code>AddHost</code>, <code>AddHosts</code>, <code>RemoveHost</code>, <code>RemoveAddress</code>, <code>RemoveCIDRs</code>. Operations are idempotent; re-adding a hostname is a no-op.</p>
         </div>
-        <span class="stack__tag">core</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">002</span>
         <div class="stack__main">
           <a class="stack__name" href="library/#thread-safety">thread-safe by default</a>
           <p class="stack__desc">All public methods take an internal mutex. Daemons, controllers, and tools that mutate hosts from multiple goroutines (kubefwd among them) can call them directly without external locking.</p>
         </div>
-        <span class="stack__tag">runtime</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">003</span>
         <div class="stack__main">
           <a class="stack__name" href="library/#inline-comments">inline comments preserved</a>
           <p class="stack__desc"><code>AddHostWithComment</code> tags entries with a source string. <code>RemoveByComment</code> removes everything tagged with that source. The library re-renders the file without losing any comment or blank line.</p>
         </div>
-        <span class="stack__tag">format</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">004</span>
         <div class="stack__main">
           <a class="stack__name" href="library/#querying">query by host, ip, or comment</a>
           <p class="stack__desc"><code>ListAddressesByHost</code>, <code>ListHostsByIP</code>, <code>ListHostsByComment</code>, <code>ListHostsByCIDR</code>. Read-only inspection without parsing or rewriting.</p>
         </div>
-        <span class="stack__tag">query</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">005</span>
         <div class="stack__main">
           <a class="stack__name" href="cli/#dns-cache-flushing">dns cache flush</a>
           <p class="stack__desc"><code>--flush</code> on the CLI or <code>TXEH_AUTO_FLUSH=1</code> in the environment runs the OS-native flush command after writes. <code>dscacheutil</code> on macOS, <code>resolvectl</code> on Linux, <code>ipconfig /flushdns</code> on Windows.</p>
         </div>
-        <span class="stack__tag">dns</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row">
-        <span class="stack__num">006</span>
         <div class="stack__main">
           <a class="stack__name" href="library/#from-a-string-in-memory">in-memory mode for tests</a>
           <p class="stack__desc">Pass <code>RawText</code> to <code>NewHosts</code> and operate on a string. <code>Save()</code> errors as expected (no path); <code>RenderHostsFile()</code> returns the mutated text. Useful in unit tests and ephemeral fixtures.</p>
         </div>
-        <span class="stack__tag">testing</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
       <li class="stack__row stack__row--more">
-        <span class="stack__num">···</span>
         <div class="stack__main">
           <a class="stack__name" href="api/">ipv4 and ipv6, custom paths, dry-run, version stamping</a>
           <p class="stack__desc">Full type and method reference in the API docs.</p>
         </div>
-        <span class="stack__tag">+ more</span>
         <span class="stack__year" aria-hidden="true">↗</span>
       </li>
-    </ol>
+    </ul>
   </section>
 
   {# CODA / sister projects, context #}
@@ -342,7 +325,7 @@ _ = hosts.Save()</pre>
       <p class="home-footer__label">txn2 / org</p>
       <p class="home-footer__text"><a href="https://txn2.com">txn2.com&nbsp;↗</a><br>
       <span class="home-footer__links__sub">canonical home of the txn2 open source organization</span></p>
-      <p class="home-footer__mono">apache 2.0 license <span class="dot">·</span> <span data-clock>·· UTC</span></p>
+      <p class="home-footer__mono">apache 2.0 license</p>
     </div>
   </div>
   <div class="home-footer__base">
@@ -350,32 +333,4 @@ _ = hosts.Save()</pre>
     <p class="home-footer__base__tag"><a href="https://txn2.com">design · txn2.com&nbsp;↗</a></p>
   </div>
 </footer>
-{% endblock %}
-
-{% block scripts %}
-{{ super() }}
-<script>
-  // Live UTC clock for rail/footer.
-  // Guarded against duplicate registration: Material's instant-nav rehydrates
-  // the body on every navigation back to the homepage; without this guard a
-  // fresh setInterval handle leaks each visit.
-  (function () {
-    if (window.__txehClock) {
-      window.__txehClock.tick();
-      return;
-    }
-    function tick() {
-      var now = new Date();
-      var hh = String(now.getUTCHours()).padStart(2, '0');
-      var mm = String(now.getUTCMinutes()).padStart(2, '0');
-      var stamp = hh + ':' + mm + ' UTC';
-      document.querySelectorAll('[data-clock]').forEach(function (el) {
-        el.textContent = stamp;
-      });
-    }
-    tick();
-    var handle = setInterval(tick, 30 * 1000);
-    window.__txehClock = { tick: tick, handle: handle };
-  })();
-</script>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,7 +3,7 @@
 {% block extrahead %}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=Instrument+Sans:wght@400..700&family=JetBrains+Mono:wght@400..700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ config.site_url }}">

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -6,25 +6,31 @@
    ─────────────────────────────────────────────────────────────── */
 
 :root {
-  --ink:        #0B0B09;
-  --ink-2:      #131310;
-  --ink-3:      #1B1A15;
-  --rule:       #2A2922;
-  --rule-2:     #3A3830;
+  /* Graphite grey ground — lifted off near-black so it reads as grey, not black. */
+  --ink:        #1E232A;
+  --ink-2:      #262C34;
+  --ink-3:      #2F3640;
+  --rule:       #3A424C;
+  --rule-2:     #47515C;
 
-  --paper:      #ECE3CE;
-  --paper-dim:  #C9C0AB;
-  --mute:       #968F80;
-  --mute-2:     #5A554B;
+  /* Cool light foreground — replaces the cream "paper". */
+  --paper:      #EDF1F5;
+  --paper-dim:  #C4CCD4;
+  --mute:       #8A95A0;
+  --mute-2:     #5C6670;
 
-  --signal:     #FF5A1F;
-  --signal-2:   #FF8A4C;
-  --acid:       #E1FF6E;
-  --cool:       #6FE1FF;
+  /* Single restrained accent (cyan) + code-syntax hues. */
+  --signal:     #4FC7E6;
+  --signal-2:   #7FD6EC;
+  --acid:       #9BCB86;
+  --cool:       #8FB6D6;
 
-  --serif:      "Fraunces", "Times New Roman", serif;
-  --sans:       "Instrument Sans", -apple-system, "Helvetica Neue", sans-serif;
-  --mono:       "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  /* --serif carries the DISPLAY face used for headings. The direction
+     moved off serif to a technical mono; the token name is kept so the
+     shared txn2 design system stays parity-mapped across sister repos. */
+  --serif:      "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  --sans:       "Geist", -apple-system, "Helvetica Neue", sans-serif;
+  --mono:       "Geist Mono", ui-monospace, "SF Mono", Menlo, monospace;
 
   --measure:    64ch;
   --rail-h:     56px;
@@ -54,21 +60,21 @@
   --md-primary-bg-color--light:    var(--paper-dim);
 
   --md-accent-fg-color:            var(--signal);
-  --md-accent-fg-color--transparent: rgba(255,90,31,0.10);
+  --md-accent-fg-color--transparent: rgba(79,199,230,0.10);
   --md-accent-bg-color:            var(--ink);
   --md-accent-bg-color--light:     var(--ink-2);
 
   --md-typeset-color:              var(--paper);
   --md-typeset-a-color:            var(--signal);
-  --md-typeset-mark-color:         rgba(255,90,31,0.25);
+  --md-typeset-mark-color:         rgba(79,199,230,0.25);
   --md-typeset-kbd-color:          var(--ink-3);
   --md-typeset-kbd-accent-color:   var(--rule-2);
   --md-typeset-kbd-border-color:   var(--rule);
 
   --md-code-bg-color:              var(--ink-2);
   --md-code-fg-color:              var(--paper);
-  --md-code-hl-color:              rgba(255,90,31,0.15);
-  --md-code-hl-color--light:       rgba(255,90,31,0.08);
+  --md-code-hl-color:              rgba(79,199,230,0.15);
+  --md-code-hl-color--light:       rgba(79,199,230,0.08);
   --md-code-hl-name-color:         var(--paper);
   --md-code-hl-keyword-color:      var(--signal);
   --md-code-hl-string-color:       var(--acid);
@@ -116,9 +122,13 @@
   --md-mermaid-sequence-loop-border-color:  var(--rule-2);
   --md-mermaid-sequence-message-fg-color:   var(--paper-dim);
   --md-mermaid-sequence-message-line-color: var(--mute);
-  --md-mermaid-sequence-note-bg-color:      var(--ink-2);
+  /* Soft filled label, not a hard-bordered box: mermaid under-sizes note
+     rects (text can exceed the rect by ~20px), and a crisp cyan border makes
+     that overflow read as broken. Border matches the fill so there is no hard
+     edge for text to cross. */
+  --md-mermaid-sequence-note-bg-color:      var(--ink-3);
   --md-mermaid-sequence-note-fg-color:      var(--paper);
-  --md-mermaid-sequence-note-border-color:  var(--signal);
+  --md-mermaid-sequence-note-border-color:  var(--ink-3);
   --md-mermaid-sequence-number-bg-color:    var(--signal);
   --md-mermaid-sequence-number-fg-color:    var(--ink);
 }
@@ -154,7 +164,7 @@ body {
 
 img { max-width: 100%; display: block; }
 
-em.serif { font-family: var(--serif); font-style: italic; font-weight: 400; }
+em.serif { font-family: var(--serif); font-style: normal; font-weight: 500; }
 
 /* Skip-to-content link */
 .skiplink {
@@ -203,15 +213,13 @@ body::before {
   background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
 }
 body::after {
-  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.45) 100%);
+  background: radial-gradient(ellipse at center, transparent 65%, rgba(0,0,0,0.14) 100%);
 }
 
-/* Subtle warm tint behind the canvas, like the reference. */
+/* Flat cool gradient behind the canvas — no colored glow. */
 .md-container,
 .page--home {
   background-image:
-    radial-gradient(circle at 18% 6%, rgba(255,90,31,0.05), transparent 38%),
-    radial-gradient(circle at 92% 84%, rgba(225,255,110,0.025), transparent 42%),
     linear-gradient(180deg, var(--ink) 0%, var(--ink-2) 100%);
 }
 
@@ -238,8 +246,8 @@ body::after {
 .blueprint__grid {
   position: absolute; inset: 0;
   background-image:
-    linear-gradient(to right, rgba(236,227,206,0.04) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(236,227,206,0.04) 1px, transparent 1px);
+    linear-gradient(to right, rgba(199,204,212,0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(199,204,212,0.04) 1px, transparent 1px);
   background-size: 64px 64px;
   -webkit-mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
           mask-image: linear-gradient(180deg, transparent, black 12%, black 88%, transparent);
@@ -267,7 +275,7 @@ header.rail {
   align-items: center;
   gap: 24px;
   padding: 14px var(--gutter);
-  background: rgba(11,11,9,0.72);
+  background: rgba(13,15,18,0.72);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -298,13 +306,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   animation: spin 24s linear infinite;
 }
 .rail__name {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 15px;
   text-transform: lowercase;
   letter-spacing: -0.01em;
   color: var(--paper);
-  font-weight: 400;
+  font-weight: 600;
 }
 .rail__sep { color: var(--rule-2); }
 .rail__sub { color: var(--mute); }
@@ -328,7 +336,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .rail__org em.serif {
   color: var(--paper);
-  font-style: italic;
+  font-style: normal;
   font-family: var(--serif);
 }
 .rail__org:hover { color: var(--signal); border-bottom-color: var(--signal); }
@@ -362,7 +370,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 @media (max-width: 540px) {
   header.rail { padding: 12px 16px; gap: 10px; }
   .rail__brand { gap: 6px; min-width: 0; }
-  .rail__name { font-size: 18px; }
+  .rail__name { font-size: 14px; }
   .rail__mark { font-size: 16px; }
   .rail__nav { gap: 12px; font-size: 11px; }
   .rail__cta { padding: 5px 8px; }
@@ -402,19 +410,27 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .hero__stamp__line--ok { color: var(--signal); }
 
 .page--home .hero__display {
+  /* Hug the title to its own width (do not grow to fill the row) so the
+     absolutely-positioned, right-pinned hero__stamp keeps a clear gutter
+     instead of colliding with the display type on wide screens. */
+  flex: 0 1 auto;
+  min-width: 0;
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(60px, 12.5vw, 220px);
-  line-height: 0.92;
-  letter-spacing: -0.04em;
-  margin-bottom: 56px;
-  font-variation-settings: "opsz" 144;
+  font-weight: 500;
+  /* Mono display runs ~1.5x wider than the former optical serif; cap the
+     ceiling well below the old ceiling so all three rows clear the stamp. */
+  font-size: clamp(24px, 3.4vw, 52px);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 .page--home .hero__row {
   display: flex; align-items: baseline; gap: clamp(12px, 2vw, 36px);
   flex-wrap: wrap;
 }
 .page--home .hero__row--1 { animation: rise 1.1s .25s both ease-out; }
+.page--home .hero__row--1 em.serif,
+.page--home .hero__row--3 em.serif { white-space: nowrap; }
 .page--home .hero__row--2 {
   padding-left: clamp(40px, 14vw, 240px);
   animation: rise 1.1s .4s both ease-out;
@@ -424,9 +440,8 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   animation: rise 1.1s .55s both ease-out;
 }
 .page--home .hero__row em.serif {
-  font-style: italic;
+  font-style: normal;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
 }
 .page--home .outline {
   -webkit-text-stroke: 1.5px var(--paper);
@@ -434,20 +449,6 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-style: normal;
   font-weight: 400;
   font-family: var(--serif);
-}
-.page--home .hero__chip {
-  font-family: var(--mono);
-  font-size: 13px;
-  letter-spacing: 0.04em;
-  color: var(--mute);
-  background: var(--ink-3);
-  border: 1px solid var(--rule);
-  padding: 6px 12px;
-  border-radius: 2px;
-  text-transform: uppercase;
-  align-self: center;
-  transform: translateY(-12px);
-  white-space: nowrap;
 }
 
 .page--home .hero__intro {
@@ -474,23 +475,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
 .page--home .hero__lede--muted { color: var(--mute); }
 
-.page--home .dropcap {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 3.4em;
-  line-height: 0.85;
-  float: left;
-  padding: 6px 10px 0 0;
-  color: var(--signal);
-  font-weight: 400;
-  font-variation-settings: "opsz" 144;
-}
 
 @media (max-width: 760px) {
   .page--home .hero__stamp {
@@ -502,7 +492,6 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   }
   .page--home .hero__intro { grid-template-columns: 1fr; padding-left: 0; }
   .page--home .hero__row--2, .page--home .hero__row--3 { padding-left: 0; }
-  .page--home .hero__chip { display: none; }
 }
 
 /* Ticker */
@@ -562,15 +551,14 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .section__title {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(36px, 5.5vw, 76px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: clamp(28px, 3.8vw, 52px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 24px;
 }
-.page--home .section__title em.serif { color: var(--signal); font-style: italic; }
+.page--home .section__title em.serif { color: var(--signal); font-style: normal; }
 .page--home .section__lede {
   color: var(--paper-dim);
   max-width: 64ch;
@@ -581,7 +569,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
 }
@@ -637,13 +625,12 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__url:hover { color: var(--signal-2); border-bottom-color: var(--signal-2); }
 .page--home .flagship__name {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-size: clamp(48px, 5vw, 80px);
-  line-height: 0.95;
-  letter-spacing: -0.03em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 3.4vw, 48px);
+  line-height: 1.0;
+  letter-spacing: -0.02em;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
   margin-bottom: 12px;
 }
 .page--home .flagship__tag {
@@ -656,7 +643,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__tag code {
   font-size: .92em;
   color: var(--signal);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   padding: 1px 6px;
   border-radius: 2px;
 }
@@ -669,7 +656,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .flagship__body code {
   color: var(--signal-2);
-  background: rgba(255,90,31,0.07);
+  background: rgba(79,199,230,0.07);
   padding: 1px 5px;
   border-radius: 2px;
   font-size: .9em;
@@ -688,7 +675,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 .page--home .flagship__card--cli { background: var(--ink-2); }
 .page--home .flagship__card--lib {
   background:
-    linear-gradient(135deg, rgba(255,90,31,0.025), transparent 60%),
+    linear-gradient(135deg, rgba(79,199,230,0.025), transparent 60%),
     var(--ink-2);
 }
 
@@ -749,7 +736,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row {
   display: grid;
-  grid-template-columns: 80px 1fr 130px 40px;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 24px;
   padding: 24px 8px;
@@ -764,21 +751,15 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .stack__row:hover .stack__name { color: var(--signal); }
 .page--home .stack__row:hover .stack__year { color: var(--signal); transform: translateX(4px); }
-.page--home .stack__num {
-  font-family: var(--mono);
-  color: var(--mute-2);
-  font-size: 13px;
-  letter-spacing: 0.08em;
-}
 .page--home .stack__name {
   display: block;
   font-family: var(--serif);
-  font-style: italic;
-  font-size: clamp(24px, 2.5vw, 34px);
+  font-style: normal;
+  font-weight: 600;
+  font-size: clamp(22px, 2.2vw, 30px);
   color: var(--paper);
-  line-height: 1.05;
+  line-height: 1.1;
   transition: color .25s;
-  font-variation-settings: "opsz" 144;
   margin-bottom: 6px;
   text-decoration: none;
 }
@@ -792,22 +773,9 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
   font-family: var(--mono);
   font-size: 0.9em;
   color: var(--signal-2);
-  background: rgba(255,90,31,0.08);
+  background: rgba(79,199,230,0.08);
   border-radius: 2px;
   padding: 1px 5px;
-}
-.page--home .stack__tag {
-  font-family: var(--mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--mute);
-  text-align: right;
-  border: 1px solid var(--rule);
-  padding: 5px 10px;
-  border-radius: 2px;
-  background: rgba(0,0,0,0.2);
-  justify-self: end;
 }
 .page--home .stack__year {
   font-family: var(--mono);
@@ -824,8 +792,7 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 
 @media (max-width: 760px) {
-  .page--home .stack__row { grid-template-columns: 50px 1fr 50px; }
-  .page--home .stack__tag { display: none; }
+  .page--home .stack__row { grid-template-columns: 1fr auto; }
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -850,13 +817,13 @@ a.rail__brand:focus-visible { outline-offset: 4px; }
 }
 .page--home .coda__big {
   font-family: var(--serif);
-  font-weight: 300;
-  font-size: clamp(28px, 3.6vw, 52px);
-  line-height: 1.15;
-  letter-spacing: -0.02em;
+  font-weight: 500;
+  font-size: clamp(14px, 1.05vw, 16px);
+  line-height: 1.6;
+  letter-spacing: 0;
   color: var(--paper);
-  font-variation-settings: "opsz" 144;
-  margin-bottom: 48px;
+  margin-bottom: 28px;
+  max-width: 72ch;
 }
 .page--home .coda__big a { color: inherit; }
 .page--home .coda__big em.serif { color: var(--signal); }
@@ -993,8 +960,8 @@ a.btn:focus-visible { outline-offset: 4px; }
 .home-footer__links a:hover { color: var(--signal); }
 .home-footer__links__sub {
   color: var(--mute);
-  font-style: italic;
-  font-family: var(--serif);
+  font-style: normal;
+  font-family: var(--mono);
   font-size: 12.5px;
   margin-left: 4px;
 }
@@ -1028,7 +995,7 @@ a.btn:focus-visible { outline-offset: 4px; }
 
 /* Header (kept on inner pages, rail-styled) */
 .md-header {
-  background: rgba(11,11,9,0.86);
+  background: rgba(13,15,18,0.86);
   backdrop-filter: blur(14px) saturate(140%);
   -webkit-backdrop-filter: blur(14px) saturate(140%);
   border-bottom: 1px solid var(--rule);
@@ -1037,17 +1004,17 @@ a.btn:focus-visible { outline-offset: 4px; }
 }
 .md-header[data-md-state="shadow"] { box-shadow: none; }
 .md-header__title {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
-  font-size: 22px;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 16px;
   letter-spacing: -0.01em;
   color: var(--paper);
 }
 .md-header__title .md-header__topic {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 300;
+  font-family: var(--mono);
+  font-style: normal;
+  font-weight: 600;
   color: var(--paper);
   transition: color .2s ease;
 }
@@ -1149,29 +1116,28 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   color: var(--mute);
 }
 
-/* Inner-page typography (Fraunces headings, paper body) */
+/* Inner-page typography — headings in the technical mono display face,
+   body in the sans. Non-italic: the direction moved off the italic serif. */
 .md-content { background: transparent; color: var(--paper); }
 .md-typeset { color: var(--paper); font-family: var(--sans); }
 
 .md-typeset h1 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(36px, 4.4vw, 60px);
-  line-height: 1.0;
-  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(30px, 4vw, 46px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
   color: var(--paper);
   margin: 0 0 0.6em;
 }
 .md-typeset h2 {
   font-family: var(--serif);
-  font-weight: 300;
-  font-style: italic;
-  font-variation-settings: "opsz" 144;
-  font-size: clamp(26px, 2.8vw, 38px);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  font-style: normal;
+  font-size: clamp(22px, 2.4vw, 32px);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
   color: var(--paper);
   margin: 1.6em 0 0.5em;
 }
@@ -1295,11 +1261,11 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 
 .md-typeset p, .md-typeset li { color: var(--paper); }
 .md-typeset strong { color: var(--paper); font-weight: 700; }
-.md-typeset em { font-family: var(--serif); font-style: italic; }
+.md-typeset em { font-family: var(--sans); font-style: italic; }
 
 .md-typeset a {
   color: var(--signal);
-  border-bottom: 1px solid rgba(255,90,31,0.25);
+  border-bottom: 1px solid rgba(79,199,230,0.25);
   text-decoration: none;
   transition: color .15s, border-color .15s;
 }
@@ -1363,7 +1329,7 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 }
 .md-clipboard {
   color: var(--mute);
-  background: rgba(11,11,9,0.6);
+  background: rgba(13,15,18,0.6);
   border-radius: 2px;
 }
 .md-clipboard:hover { color: var(--signal); }
@@ -1386,14 +1352,15 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 /* Admonitions */
 .md-typeset .admonition,
 .md-typeset details {
+  --adm: var(--signal);
   background: var(--ink-2);
   border: 1px solid var(--rule);
-  border-left: 2px solid var(--signal);
   border-radius: 2px;
   box-shadow: none;
   font-size: 14.5px;
   color: var(--paper-dim);
 }
+/* Type is signalled by the title + icon color, not an accent left rail. */
 .md-typeset .admonition-title,
 .md-typeset summary {
   background: transparent;
@@ -1402,22 +1369,32 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--paper);
+  color: var(--adm);
   border-bottom: 1px solid var(--rule);
 }
 .md-typeset .admonition-title::before,
-.md-typeset summary::before { background-color: var(--signal); }
+.md-typeset summary::before { background-color: var(--adm); }
 
 .md-typeset .admonition.note,
-.md-typeset details.note { border-left-color: var(--cool); }
+.md-typeset details.note { --adm: var(--cool); }
 .md-typeset .admonition.warning,
-.md-typeset details.warning { border-left-color: var(--signal); }
+.md-typeset details.warning { --adm: var(--signal); }
 .md-typeset .admonition.danger,
-.md-typeset details.danger { border-left-color: var(--signal); }
+.md-typeset details.danger { --adm: var(--signal); }
 .md-typeset .admonition.tip,
-.md-typeset details.tip { border-left-color: var(--acid); }
+.md-typeset details.tip { --adm: var(--acid); }
 .md-typeset .admonition.success,
-.md-typeset details.success { border-left-color: var(--acid); }
+.md-typeset details.success { --adm: var(--acid); }
+
+/* Material ships per-type border + icon colors as 3-class selectors
+   (e.g. `.md-typeset .admonition.warning { border-color: #ff9100 }`) that
+   outrank the neutral base rule above and reintroduce amber/blue boxes.
+   Match that specificity with `[class]` so every admonition keeps a neutral
+   border and takes its title + icon color only from --adm — no colored box. */
+.md-typeset .admonition[class],
+.md-typeset details[class] { border-color: var(--rule); }
+.md-typeset .admonition[class] > .admonition-title::before,
+.md-typeset details[class] > summary::before { background-color: var(--adm); }
 
 /* Tables */
 .md-typeset table:not([class]) {
@@ -1514,10 +1491,20 @@ a.md-header__button.md-logo:hover ~ .md-header__title .md-header__topic,
 .md-copyright a:hover { color: var(--signal); }
 .md-social a { color: var(--mute); }
 .md-social a:hover { color: var(--signal); }
-.md-footer__title { background: var(--ink); color: var(--paper); }
-.md-footer__direction { color: var(--mute); font-family: var(--mono); }
-.md-footer__link { color: var(--paper-dim); }
-.md-footer__link:hover { color: var(--signal); opacity: 1; }
+.md-footer__inner { padding: 8px 0; gap: 12px; }
+.md-footer__link { color: var(--paper-dim); padding: 20px 16px; border-radius: 6px; transition: background .2s, color .2s; opacity: 1; }
+.md-footer__link:hover { color: var(--signal); background: var(--ink-3); }
+.md-footer__title { background: transparent; color: var(--paper); font-weight: 500; line-height: 1.3; }
+.md-footer__direction {
+  color: var(--mute);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 1;
+}
+.md-footer__button { color: var(--mute); transition: color .2s; }
+.md-footer__link:hover .md-footer__button { color: var(--signal); }
 
 /* Hide Material's default content button on homepage */
 .page--home .md-content__button { display: none; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ repo_url: https://github.com/txn2/txeh
 repo_name: txn2/txeh
 edit_uri: edit/master/docs/
 
-copyright: Copyright &copy; 2019 - 2026 Craig Johnston / Deasil Works, Inc.
+copyright: Copyright &copy; 2019 - 2026 <a href="https://imti.co">Craig Johnston</a> / <a href="https://deasil.works">Deasil Works, Inc.</a> / <a href="https://plexara.io">Plexara</a>
 
 theme:
   name: material


### PR DESCRIPTION
Ports the txn2 docs design-system re-skin from mcp-data-platform so the sister documentation sites stay visually parity-mapped.

Type and color: replaces the Fraunces display serif with Geist / Geist Mono (non-italic mono headings, Geist body) and moves the palette to a graphite-grey ground (`--ink #1E232A`) with a single restrained cyan accent, remapping the former orange tints to cyan.

Chrome: removes the live UTC clock from the homepage rail and footer, de-rails admonitions (Material's per-type border colors neutralized so type reads from the title/icon color), cleans up the prev/next footer, and links the copyright to imti.co / deasil.works / plexara.io.

Homepage: removes the split-word dropcap, the 001-00N numbering and caps chips from the feature list, and the hero version/go badge. The mono hero display is capped so all three rows clear the right-pinned stamp.

Verification: `mkdocs build --strict` passes with no warnings (the gate CI runs in `.github/workflows/docs.yml`); the homepage was checked in a browser.
