### PR TITLE
chore(ci): bump github/codeql-action to 4.37.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v3
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v3
 
       - name: Perform Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,6 +28,6 @@ jobs:
           results_format: sarif
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Rollup of the four open Dependabot PRs. Each bumps a different `github/codeql-action` sub-action, and all four target the same commit SHA (`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`), so they are combined here into one change.

| PR | Sub-action | From | To |
|----|-----------|------|-----|
| #107 | `init` | 4.36.2 | 4.37.0 |
| #108 | `autobuild` | 4.36.2 | 4.37.0 |
| #110 | `analyze` | 4.36.2 | 4.37.0 |
| #109 | `upload-sarif` | 4.36.3 | 4.37.0 |

Files touched: `.github/workflows/codeql.yml` and `.github/workflows/scorecard.yml`.

The inline `# v3` comments were left as-is since that is what the existing pins and the Dependabot PRs both use.

Closes #107
Closes #108
Closes #109
Closes #110